### PR TITLE
Added Docker daemon/service instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Which can be achieved by one of following commands:
 
 After making sure that Docker daemon is up and running, you are ready to build/start containers.
 
-To build the container, run::
+To build the container, run:: (You may need to have root privelege for using Docker depending on Docker Daemon. If it is the case, add `sudo` to commands.)
 
   $ docker build -t itucsdb .
 

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,31 @@ how deployments are going.
 
 By default, the project is meant to be used with a PostgreSQL server.
 You can use any PostgreSQL installation but a Dockerfile is provided
-for convenience. To build the container, run::
+for convenience. Docker will host the PostgreSQL client under the hood.
+Docker is a container for your programs which allows 
+you to unify development/testing/production environments.
+
+In MacOS, you can install Docker from its official website
+https://www.docker.com/products/docker-desktop
+
+Many Linux distributions has Docker in its official package repositories.
+https://docs.docker.com/install
+
+Before running Docker, you may need to start Docker service in Linux. This can be done by many ways,
+one is explained below:
+https://docs.docker.com/install/linux/linux-postinstall
+It is quite advanced for new Linux user but it is manageble.
+
+Another options is to start Docker Daemon manually, 
+Which can be achieved by one of following commands:
+
+* `sudo systemctl start docker`
+* `sudo service docker start` 
+* `sudo dockerd`
+
+After making sure that Docker daemon is up and running, you are ready to build/start containers.
+
+To build the container, run::
 
   $ docker build -t itucsdb .
 

--- a/README.rst
+++ b/README.rst
@@ -92,13 +92,13 @@ It is quite advanced for new Linux user but it is manageble.
 Another options is to start Docker Daemon manually, 
 Which can be achieved by one of following commands:
 
-* `sudo systemctl start docker`
-* `sudo service docker start` 
-* `sudo dockerd`
+* $ ``sudo systemctl start docker``
+* $ ``sudo service docker start``
+* $ ``sudo dockerd``
 
 After making sure that Docker daemon is up and running, you are ready to build/start containers.
 
-To build the container, run:: (You may need to have root privelege for using Docker depending on Docker Daemon. If it is the case, add `sudo` to commands.)
+To build the container, run:: (You may need to have root privelege for using Docker depending on Docker Daemon. If it is the case, add ``sudo`` to commands.)
 
   $ docker build -t itucsdb .
 


### PR DESCRIPTION
Last year, I used Docker in my DB project in order to get my hands dirty with Docker. I had some troubles while using Docker at start which was related to Docker Daemon. I was less proficient in Linux and I spent my night for getting Docker working.

I used Manjaro Linux (derivate of Arch) last year and pacman has dockerd, has a separate command for starting Docker service named as ``dockerd``.